### PR TITLE
Added compatibility for intel macs

### DIFF
--- a/lib/app/services/file_service.dart
+++ b/lib/app/services/file_service.dart
@@ -23,7 +23,7 @@ class FileService {
 
   Future<String?> get synergyServerPath async => switch (Abi.current()) {
         Abi.macosArm64 => _getMacSynergy("synergy_arm64"),
-        Abi.macosX64 => _getMacSynergy("synergy_x64"),
+        Abi.macosX64 => _getMacSynergy("synergy_ x64"),
         Abi.windowsX64 => "synergy_x64.dll",
         Abi.linuxX64 => await _getLinuxSynergy("synergy_x64"),
         _ => null,

--- a/lib/app/services/file_service.dart
+++ b/lib/app/services/file_service.dart
@@ -29,12 +29,33 @@ class FileService {
         _ => null,
       };
 
-  String? get libUsbBinaryPath => switch (defaultTargetPlatform) {
-        TargetPlatform.macOS => "libusb.dylib",
-        TargetPlatform.windows => "libusb.dll",
-        TargetPlatform.linux => "$_executablePath/lib/libusb.so",
-        _ => null,
-      };
+  String? get libUsbBinaryPath {
+    return switch (defaultTargetPlatform) {
+      TargetPlatform.macOS => () {
+          // intel macs and apple sillicon macs have different brew install locations:
+          // for apple sillicon:
+          if (File('/opt/homebrew/lib/libusb-1.0.0.dylib').existsSync()) {
+            return '/opt/homebrew/lib/libusb-1.0.0.dylib';
+          }
+          // for intel macs:
+          if (File('/usr/local/lib/libusb-1.0.0.dylib').existsSync()) {
+            return '/usr/local/lib/libusb-1.0.0.dylib';
+          }
+          if (File('/opt/homebrew/lib/libusb.dylib').existsSync()) {
+            return '/opt/homebrew/lib/libusb.dylib';
+          }
+          if (File('/usr/local/lib/libusb.dylib').existsSync()) {
+            return '/usr/local/lib/libusb.dylib';
+          }
+
+          print('LibUsb not found at expected macOS locations.');
+          return null;
+        }(),
+      TargetPlatform.windows => "libusb.dll",
+      TargetPlatform.linux => "$_executablePath/lib/libusb.so",
+      _ => null,
+    };
+  }
 
   String get dbDirectory => _getDirectory('db');
 


### PR DESCRIPTION
I changed up the `FileService`'s `get libUsbBinaryPath` function to return the homebrew install locations from their specified directory, previously this was throwing an error inside the start() function which caused the app to show a black screen.

fixes #45

Before and after (on intel mac):
 
<img width="612" height="912" alt="Screenshot 2025-07-25 at 11 30 57 PM" src="https://github.com/user-attachments/assets/a1d43b3c-2533-4ab3-8ed4-9a0d00d76408" />
<img width="612" height="912" alt="Screenshot 2025-07-25 at 11 31 43 PM" src="https://github.com/user-attachments/assets/eef8684d-a7a7-43e3-b06f-95dbc84f9393" />
