### PR TITLE
docs: Auto-translate README and Wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,35 @@
+
+<div align="right">
+  <details>
+    <summary >🌐 Language</summary>
+    <div>
+      <div align="center">
+        <a href="https://openaitx.github.io/view.html?user=rohitsangwan01&project=uni_control_hub&lang=en">English</a>
+        | <a href="https://openaitx.github.io/view.html?user=rohitsangwan01&project=uni_control_hub&lang=zh-CN">简体中文</a>
+        | <a href="https://openaitx.github.io/view.html?user=rohitsangwan01&project=uni_control_hub&lang=zh-TW">繁體中文</a>
+        | <a href="https://openaitx.github.io/view.html?user=rohitsangwan01&project=uni_control_hub&lang=ja">日本語</a>
+        | <a href="https://openaitx.github.io/view.html?user=rohitsangwan01&project=uni_control_hub&lang=ko">한국어</a>
+        | <a href="https://openaitx.github.io/view.html?user=rohitsangwan01&project=uni_control_hub&lang=hi">हिन्दी</a>
+        | <a href="https://openaitx.github.io/view.html?user=rohitsangwan01&project=uni_control_hub&lang=th">ไทย</a>
+        | <a href="https://openaitx.github.io/view.html?user=rohitsangwan01&project=uni_control_hub&lang=fr">Français</a>
+        | <a href="https://openaitx.github.io/view.html?user=rohitsangwan01&project=uni_control_hub&lang=de">Deutsch</a>
+        | <a href="https://openaitx.github.io/view.html?user=rohitsangwan01&project=uni_control_hub&lang=es">Español</a>
+        | <a href="https://openaitx.github.io/view.html?user=rohitsangwan01&project=uni_control_hub&lang=it">Italiano</a>
+        | <a href="https://openaitx.github.io/view.html?user=rohitsangwan01&project=uni_control_hub&lang=ru">Русский</a>
+        | <a href="https://openaitx.github.io/view.html?user=rohitsangwan01&project=uni_control_hub&lang=pt">Português</a>
+        | <a href="https://openaitx.github.io/view.html?user=rohitsangwan01&project=uni_control_hub&lang=nl">Nederlands</a>
+        | <a href="https://openaitx.github.io/view.html?user=rohitsangwan01&project=uni_control_hub&lang=pl">Polski</a>
+        | <a href="https://openaitx.github.io/view.html?user=rohitsangwan01&project=uni_control_hub&lang=ar">العربية</a>
+        | <a href="https://openaitx.github.io/view.html?user=rohitsangwan01&project=uni_control_hub&lang=fa">فارسی</a>
+        | <a href="https://openaitx.github.io/view.html?user=rohitsangwan01&project=uni_control_hub&lang=tr">Türkçe</a>
+        | <a href="https://openaitx.github.io/view.html?user=rohitsangwan01&project=uni_control_hub&lang=vi">Tiếng Việt</a>
+        | <a href="https://openaitx.github.io/view.html?user=rohitsangwan01&project=uni_control_hub&lang=id">Bahasa Indonesia</a>
+        | <a href="https://openaitx.github.io/view.html?user=rohitsangwan01&project=uni_control_hub&lang=as">অসমীয়া</
+      </div>
+    </div>
+  </details>
+</div>
+
 # UniControlHub
 
 [![](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub&color=%23fe8e86)](https://github.com/sponsors/rohitsangwan01)


### PR DESCRIPTION
Added language badges to the README for easier access to translated versions: German, Spanish, French, Japanese, Korean, Portuguese, and Russian 20 languages.
System will auto-update translation for README and Wiki when this repository updated, and support multiple languages google/bing SEO search, and it's open source project, we can change web or local file mode.

The updated links can be previewed in my forked repository: https://github.com/openaitx-system/uni_control_hub/tree/Auto_translate_README_and_Wiki

Demo links : 
- [Español](https://openaitx.github.io/view.html?user=rohitsangwan01&project=uni_control_hub&lang=es)
- [简体中文](https://openaitx.github.io/view.html?user=rohitsangwan01&project=uni_control_hub&lang=zh-CN)
- [日本語](https://openaitx.github.io/view.html?user=rohitsangwan01&project=uni_control_hub&lang=ja)
- [한국어](https://openaitx.github.io/view.html?user=rohitsangwan01&project=uni_control_hub&lang=ko)
- [Français](https://openaitx.github.io/view.html?user=rohitsangwan01&project=uni_control_hub&lang=fr)
..


<img width="1178" height="537" alt="Image" src="https://github.com/user-attachments/assets/7cd54a88-59c1-455f-9c7d-2db7f05b2962  " />

If this doesn't align with your expectations, feel free to close this PR. Thanks for your time! 🙌
