### PR TITLE
Fix Android BLE support and mouse responsiveness

### DIFF
--- a/lib/app/client/client_screen.dart
+++ b/lib/app/client/client_screen.dart
@@ -33,6 +33,7 @@ class ClientScreen extends ScreenInterface {
   int _accumX = 0;
   int _accumY = 0;
   Timer? _mouseTimer;
+  final Stopwatch _mouseStopwatch = Stopwatch()..start();
   int _lastSentMs = 0;
   // 15 ms = one BLE connection interval on Android — the max rate Windows BLE
   // peripheral can deliver notifications without the internal queue growing.
@@ -85,7 +86,7 @@ class ClientScreen extends ScreenInterface {
 
   void _scheduleMouse() {
     if (_mouseTimer != null) return; // timer already running, delta will be caught
-    final elapsed = DateTime.now().millisecondsSinceEpoch - _lastSentMs;
+    final elapsed = _mouseStopwatch.elapsedMilliseconds - _lastSentMs;
     if (elapsed >= _bleIntervalMs) {
       // BLE window is free — send right now, zero added latency
       _flushMouse();
@@ -100,19 +101,23 @@ class ClientScreen extends ScreenInterface {
 
   void _flushMouse() {
     _mouseTimer = null;
-    _lastSentMs = DateTime.now().millisecondsSinceEpoch;
-    final int dx = _accumX;
-    final int dy = _accumY;
-    _accumX = 0;
-    _accumY = 0;
+    if (_accumX == 0 && _accumY == 0) return;
+    final int dx = _accumX.clamp(-127, 127);
+    final int dy = _accumY.clamp(-127, 127);
+    _accumX -= dx;
+    _accumY -= dy;
     if (dx == 0 && dy == 0) return;
+    _lastSentMs = _mouseStopwatch.elapsedMilliseconds;
     var r = Uint8List(5);
     r[0] = 0x02;
     r[1] = buttonPressed ?? 0;
-    r[2] = dx.clamp(-127, 127) & 0xFF;
-    r[3] = dy.clamp(-127, 127) & 0xFF;
+    r[2] = dx & 0xFF;
+    r[3] = dy & 0xFF;
     r[4] = 0;
     _addInputReport(r);
+    if (_accumX != 0 || _accumY != 0) {
+      _scheduleMouse();
+    }
   }
 
   @override
@@ -240,9 +245,14 @@ class ClientScreen extends ScreenInterface {
   }
 
   void _moveMouseMultipleEvents({int? x, int? y, int count = 100}) {
-    _accumX += (x ?? 0) * count;
-    _accumY += (y ?? 0) * count;
-    _scheduleMouse();
+    if (count <= 0) return;
+    final int dx = x ?? 0;
+    final int dy = y ?? 0;
+    for (int i = 0; i < count; i++) {
+      _accumX += dx;
+      _accumY += dy;
+      _scheduleMouse();
+    }
   }
 
   Future<void> _addInputReport(List<int> inputReport) =>

--- a/lib/app/client/client_screen.dart
+++ b/lib/app/client/client_screen.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
@@ -29,6 +30,14 @@ class ClientScreen extends ScreenInterface {
   int relativeY = 0;
   int? buttonPressed;
 
+  int _accumX = 0;
+  int _accumY = 0;
+  Timer? _mouseTimer;
+  int _lastSentMs = 0;
+  // 15 ms = one BLE connection interval on Android — the max rate Windows BLE
+  // peripheral can deliver notifications without the internal queue growing.
+  static const _bleIntervalMs = 15;
+
   @override
   void mouseDown(int buttonID) {
     var reportData = Uint8List(5);
@@ -59,29 +68,51 @@ class ClientScreen extends ScreenInterface {
 
   @override
   void mouseMove(int x, int y) {
-    var reportData = Uint8List(5);
-    reportData[0] = 0x02; // Report ID
-    reportData[1] = buttonPressed ?? 0; // Button state
-    reportData[2] = x - relativeX; // X movement
-    reportData[3] = y - relativeY; // Y movement
-    reportData[4] = 0; // Wheel movement
-    _addInputReport(reportData);
+    _accumX += x - relativeX;
+    _accumY += y - relativeY;
     relativeX = x;
     relativeY = y;
     onMouseMove?.call(x, y);
+    _scheduleMouse();
   }
 
   @override
   void mouseRelativeMove(int x, int y) {
-    var reportData = Uint8List(5);
-    reportData[0] = 0x02; // Report ID
-    reportData[1] = buttonPressed ?? 0; // Button state
-    reportData[2] = x; // X movement
-    reportData[3] = y; // Y movement
-    reportData[4] = 0; // Wheel movement
-    _addInputReport(reportData);
-    relativeX = x;
-    relativeY = y;
+    _accumX += x;
+    _accumY += y;
+    _scheduleMouse();
+  }
+
+  void _scheduleMouse() {
+    if (_mouseTimer != null) return; // timer already running, delta will be caught
+    final elapsed = DateTime.now().millisecondsSinceEpoch - _lastSentMs;
+    if (elapsed >= _bleIntervalMs) {
+      // BLE window is free — send right now, zero added latency
+      _flushMouse();
+    } else {
+      // Inside the current window — wait only the remaining slice
+      _mouseTimer = Timer(
+        Duration(milliseconds: _bleIntervalMs - elapsed),
+        _flushMouse,
+      );
+    }
+  }
+
+  void _flushMouse() {
+    _mouseTimer = null;
+    _lastSentMs = DateTime.now().millisecondsSinceEpoch;
+    final int dx = _accumX;
+    final int dy = _accumY;
+    _accumX = 0;
+    _accumY = 0;
+    if (dx == 0 && dy == 0) return;
+    var r = Uint8List(5);
+    r[0] = 0x02;
+    r[1] = buttonPressed ?? 0;
+    r[2] = dx.clamp(-127, 127) & 0xFF;
+    r[3] = dy.clamp(-127, 127) & 0xFF;
+    r[4] = 0;
+    _addInputReport(r);
   }
 
   @override
@@ -209,15 +240,9 @@ class ClientScreen extends ScreenInterface {
   }
 
   void _moveMouseMultipleEvents({int? x, int? y, int count = 100}) {
-    for (int i = 0; i < count; i++) {
-      var reportData = Uint8List(5);
-      reportData[0] = 0x02; // Report ID
-      reportData[1] = 0; // Button state
-      reportData[2] = x ?? 0; // X movement
-      reportData[3] = y ?? 0; // Y movement
-      reportData[4] = 0; // Wheel movement
-      _addInputReport(reportData);
-    }
+    _accumX += (x ?? 0) * count;
+    _accumY += (y ?? 0) * count;
+    _scheduleMouse();
   }
 
   Future<void> _addInputReport(List<int> inputReport) =>

--- a/lib/app/communication/ble/ble_peripheral_communication.dart
+++ b/lib/app/communication/ble/ble_peripheral_communication.dart
@@ -133,6 +133,21 @@ class BlePeripheralCommunication {
       _handleCharacteristicSubscriptionChange,
     );
 
+    // Android BLE centrals signal readiness via connection state, not
+    // characteristic subscription. Register the callback so Android phones
+    // are added/removed as clients just like iOS devices.
+    BlePeripheral.setConnectionStateChangeCallback((deviceId, connected) {
+      if (connected) {
+        if (_addNewClient(deviceId)) {
+          logInfo("BLE device connected (Android): $deviceId");
+        }
+      } else if (_communicationService.existsDevice(deviceId)) {
+        if (_communicationService.removeClient(deviceId)) {
+          logInfo("BLE device disconnected: $deviceId");
+        }
+      }
+    });
+
     BlePeripheral.setReadRequestCallback(
       _blePeripheralUtils.onReadRequest,
     );


### PR DESCRIPTION
## Changes

**1. Android BLE fix** (`ble_peripheral_communication.dart`)
Android phones now connect via Bluetooth. Previously only iOS was supported.

**2. Mouse responsiveness fix** (`client_screen.dart`)
- Added motion delta accumulation + 15 ms throttle aligned to BLE connection interval
- Removed `while` loop in `_flushMouse` that was flooding the BLE queue
- Fixed incorrect `relativeX/Y` assignment in `mouseRelativeMove`